### PR TITLE
* export react(-dom) interface in xext.

### DIFF
--- a/src/react-dom.js
+++ b/src/react-dom.js
@@ -1,0 +1,17 @@
+import {ReactDOM} from 'xext';
+
+export const createPortal = ReactDOM.createPortal;
+export const findDOMNode = ReactDOM.findDOMNode;
+export const flushSync = ReactDOM.flushSync;
+export const hydrate = ReactDOM.hydrate;
+export const render = ReactDOM.render;
+export const unmountComponentAtNode = ReactDOM.unmountComponentAtNode;
+export const unstable_batchedUpdates = ReactDOM.unstable_batchedUpdates;
+export const unstable_createPortal = ReactDOM.unstable_createPortal;
+export const unstable_createRoot = ReactDOM.unstable_createRoot;
+export const unstable_deferredUpdates = ReactDOM.unstable_deferredUpdates;
+export const unstable_flushControlled = ReactDOM.unstable_flushControlled;
+export const unstable_interactiveUpdates = ReactDOM.unstable_interactiveUpdates;
+export const unstable_renderSubtreeIntoContainercallback = ReactDOM.unstable_renderSubtreeIntoContainercallback;
+
+export default ReactDOM;

--- a/src/react.js
+++ b/src/react.js
@@ -1,0 +1,19 @@
+import {React} from 'xext';
+
+export const Children = React.Children;
+export const Component = React.Component;
+export const Fragment = React.Fragment;
+export const StrictMode = React.StrictMode;
+export const PureComponent = React.PureComponent;
+export const cloneElement = React.cloneElement;
+export const createContext = React.createContext;
+export const createElement = React.createElement;
+export const createFactory = React.createFactory;
+export const createRef = React.createRef;
+export const forwardRef = React.forwardRef;
+export const isValidElement = React.isValidElement;
+export const unstable_AsyncMode = React.unstable_AsyncMode;
+export const unstable_Profiler = React.unstable_Profiler;
+export const version = React.version;
+
+export default React;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,7 +27,12 @@ module.exports = function(env, argv) {
             modules: [
                 path.join(__dirname, './src'),
                 'node_modules'
-            ]
+            ],
+
+            alias:{
+                react: 'react.js',
+                "react-dom": 'react-dom.js'
+            }
         },
 
         module: {


### PR DESCRIPTION
按照之前的思路导出了接口，可以解决其他`react`组件在使用`import {} from 'react'`的时候出现类似无法找到父类构造函数等问题。 
本来想尝试在`xext`中解决，但是没有找到比较通用的方法，还请浩哥考虑一下。